### PR TITLE
feat(features): add graphql support

### DIFF
--- a/src/backend/browser.ts
+++ b/src/backend/browser.ts
@@ -1,4 +1,4 @@
 import { setupWorker } from "msw";
-import { handlers } from "./handlers";
+import { gqlHandlers, restHandlers } from "./handlers";
 
-export const worker = setupWorker(...handlers);
+export const worker = setupWorker(...restHandlers, ...gqlHandlers);

--- a/src/backend/db/database.ts
+++ b/src/backend/db/database.ts
@@ -1,0 +1,39 @@
+import { faker } from "@faker-js/faker";
+import { factory, oneOf, primaryKey } from "@mswjs/data";
+
+function makeAutoIncrement() {
+  let id = 0;
+
+  return () => ++id;
+}
+
+export const db = factory({
+  user: {
+    __typename: () => "User",
+    id: primaryKey(makeAutoIncrement()),
+    username: String,
+    password: String,
+    profile: oneOf("profile"),
+  },
+  profile: {
+    __typename: () => "Profile",
+    id: primaryKey(makeAutoIncrement()),
+    firstName: faker.name.firstName,
+    lastName: faker.name.lastName,
+    logo: faker.image.business,
+  },
+});
+
+if (db.user.count() === 0) {
+  db.user.create({
+    username: "admin",
+    password: "admin",
+    profile: db.profile.create(),
+  });
+
+  db.user.create({
+    username: "test",
+    password: "test",
+    profile: db.profile.create(),
+  });
+}

--- a/src/backend/db/repository/error.ts
+++ b/src/backend/db/repository/error.ts
@@ -1,0 +1,62 @@
+type TRepositoryError =
+  | "AuthenticationError"
+  | "BadRequestError"
+  | "NotFoundError"
+  | "ServerError";
+
+export class RepositoryError extends Error {
+  public name: "RepositoryError";
+  public code: number;
+  public type: TRepositoryError;
+
+  constructor(message: string, code: number, type: TRepositoryError) {
+    super(message);
+    this.name = "RepositoryError";
+    this.code = code;
+    this.type = type;
+  }
+
+  static isRespositoryError = (error: unknown): error is RepositoryError => {
+    return (error as RepositoryError)?.name === "RepositoryError";
+  };
+
+  static toJson = (error: unknown) => {
+    if (this.isRespositoryError(error)) {
+      const { code, type, message } = error;
+      return { code, type, message };
+    }
+
+    const { code, type, message } = new ServerError();
+    return { code, type, message };
+  };
+}
+
+export class ServerError extends RepositoryError {
+  constructor() {
+    super("Internal server error", 500, "ServerError");
+  }
+}
+
+export class BadRequest extends RepositoryError {
+  constructor(message: string) {
+    super(message, 400, "BadRequestError");
+  }
+}
+
+export class Unauthorized extends RepositoryError {
+  constructor() {
+    super("Unauthorized", 401, "AuthenticationError");
+  }
+}
+
+export class NotFound extends RepositoryError {
+  constructor(message: string) {
+    super(message, 404, "NotFoundError");
+  }
+}
+
+export class InvalidCredentials extends BadRequest {
+  constructor() {
+    super("Invalid credentials");
+  }
+}

--- a/src/backend/db/repository/index.ts
+++ b/src/backend/db/repository/index.ts
@@ -1,2 +1,2 @@
-export * from "./database";
+export * from "./error";
 export * from "./repository";

--- a/src/backend/db/repository/repository.ts
+++ b/src/backend/db/repository/repository.ts
@@ -1,0 +1,80 @@
+import { bearerSchema, JWT } from "@backend/utils";
+import { loginReqSchema, refreshReqSchema } from "@models";
+import { db } from "../database";
+import { InvalidCredentials, NotFound, Unauthorized } from "./error";
+
+export class BackendRepository {
+  static login = async (payload: unknown) => {
+    const loginReq = loginReqSchema.safeParse(payload);
+
+    if (!loginReq.success) {
+      throw new InvalidCredentials();
+    }
+
+    const { data } = loginReq;
+
+    const userRecord = db.user.findFirst({
+      where: { username: { equals: data.username } },
+    });
+
+    if (!userRecord) {
+      throw new InvalidCredentials();
+    }
+
+    if (userRecord.password !== data.password) {
+      throw new InvalidCredentials();
+    }
+
+    const token = await JWT.jwt({ id: userRecord.id });
+    const refreshToken = crypto.randomUUID();
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { password, ...user } = userRecord;
+
+    return { token, refreshToken, user };
+  };
+
+  static refresh = async (payload: unknown, encodedToken: unknown) => {
+    const refreshReq = refreshReqSchema.safeParse(payload);
+    const jwt = bearerSchema.safeParse(encodedToken);
+
+    if (!refreshReq.success || !jwt.success) {
+      throw new Unauthorized();
+    }
+    const { userId } = JWT.decode(jwt.data);
+
+    const token = await JWT.jwt({ id: userId });
+    const refreshToken = crypto.randomUUID();
+
+    return { token, refreshToken };
+  };
+
+  static userList = async () => {
+    return db.user.findMany({});
+  };
+
+  static user = async (id: number) => {
+    const userRecord = db.user.findFirst({ where: { id: { equals: id } } });
+
+    if (!userRecord) {
+      throw new NotFound("User does not exists");
+    }
+
+    return userRecord;
+  };
+
+  static profileList = async () => {
+    return db.profile.findMany({});
+  };
+
+  static profile = async (id: number) => {
+    const profileRecord = db.profile.findFirst({
+      where: { id: { equals: id } },
+    });
+
+    if (!profileRecord) {
+      throw new NotFound("Profile does not exists");
+    }
+
+    return profileRecord;
+  };
+}

--- a/src/backend/handlers/authMiddleware.ts
+++ b/src/backend/handlers/authMiddleware.ts
@@ -1,4 +1,5 @@
 import { ResponseComposition, rest, RestContext, RestRequest } from "msw";
+import { RepositoryError, Unauthorized } from "@backend/db";
 import { isAuthenticated, isPublicApi, makeUrl } from "@backend/utils";
 
 async function authMiddleware(
@@ -7,7 +8,8 @@ async function authMiddleware(
   ctx: RestContext
 ) {
   if (!isPublicApi(req.url.pathname) && !(await isAuthenticated(req.headers))) {
-    return res(ctx.status(401), ctx.json({ message: "Unauthorized" }));
+    const error = RepositoryError.toJson(new Unauthorized());
+    return res(ctx.status(error.code), ctx.json(error));
   }
   return undefined;
 }

--- a/src/backend/handlers/index.ts
+++ b/src/backend/handlers/index.ts
@@ -1,13 +1,17 @@
-import { RestHandler } from "msw";
+import { GraphQLHandler, RestHandler } from "msw";
 import { db } from "../db";
 import { makeUrl } from "../utils";
 import authHandlers from "./auth";
 import authMiddleware from "./authMiddleware";
 import delayMiddleware from "./delayMiddleware";
 
-export const handlers = ([] as RestHandler[])
+export const restHandlers = ([] as RestHandler[])
   .concat(delayMiddleware)
   .concat(authMiddleware)
   .concat(authHandlers)
   .concat(db.user.toHandlers("rest", makeUrl()))
   .concat(db.profile.toHandlers("rest", makeUrl()));
+
+export const gqlHandlers = ([] as GraphQLHandler[]).concat(
+  db.user.toHandlers("graphql", makeUrl("", "gql"))
+);

--- a/src/backend/handlers/index.ts
+++ b/src/backend/handlers/index.ts
@@ -1,17 +1,27 @@
 import { GraphQLHandler, RestHandler } from "msw";
-import { db } from "../db";
-import { makeUrl } from "../utils";
-import authHandlers from "./auth";
+import {
+  gqlHandlers as authGqlHandlers,
+  restHandlers as authRestHandlers,
+} from "./auth";
 import authMiddleware from "./authMiddleware";
 import delayMiddleware from "./delayMiddleware";
+import {
+  gqlHandlers as profileGqlHandlers,
+  restHandlers as profileRestHandlers,
+} from "./profile";
+import {
+  gqlHandlers as userGqlHandlers,
+  restHandlers as userRestHandlers,
+} from "./user";
 
 export const restHandlers = ([] as RestHandler[])
   .concat(delayMiddleware)
   .concat(authMiddleware)
-  .concat(authHandlers)
-  .concat(db.user.toHandlers("rest", makeUrl()))
-  .concat(db.profile.toHandlers("rest", makeUrl()));
+  .concat(authRestHandlers)
+  .concat(userRestHandlers)
+  .concat(profileRestHandlers);
 
-export const gqlHandlers = ([] as GraphQLHandler[]).concat(
-  db.user.toHandlers("graphql", makeUrl("", "gql"))
-);
+export const gqlHandlers = ([] as GraphQLHandler[])
+  .concat(authGqlHandlers)
+  .concat(userGqlHandlers)
+  .concat(profileGqlHandlers);

--- a/src/backend/handlers/profile.ts
+++ b/src/backend/handlers/profile.ts
@@ -3,12 +3,9 @@ import { BackendRepository, RepositoryError } from "../db";
 import { makeUrl } from "../utils";
 
 export const restHandlers = [
-  rest.post(makeUrl("login"), async (req, res, ctx) => {
+  rest.get(makeUrl("profiles"), async (req, res, ctx) => {
     try {
-      const payload = await req.json();
-
-      const response = await BackendRepository.login(payload);
-
+      const response = await BackendRepository.profileList();
       return res(ctx.status(200), ctx.json(response));
     } catch (err) {
       const error = RepositoryError.toJson(err);
@@ -16,13 +13,10 @@ export const restHandlers = [
     }
   }),
 
-  rest.post(makeUrl("refresh"), async (req, res, ctx) => {
+  rest.get(makeUrl("profiles/:id"), async (req, res, ctx) => {
     try {
-      const payload = await req.json();
-      const encodedToken = req.headers.get("Authorization");
-
-      const response = await BackendRepository.refresh(payload, encodedToken);
-
+      const { id } = req.params;
+      const response = await BackendRepository.profile(+id);
       return res(ctx.status(200), ctx.json(response));
     } catch (err) {
       const error = RepositoryError.toJson(err);
@@ -32,12 +26,19 @@ export const restHandlers = [
 ];
 
 export const gqlHandlers = [
-  graphql.mutation("Login", async (req, res, ctx) => {
+  graphql.query("GetProfiles", async (req, res, ctx) => {
     try {
-      const payload = req.variables;
+      const response = await BackendRepository.profileList();
+      return res(ctx.data(response));
+    } catch (err) {
+      return res(ctx.errors([RepositoryError.toJson(err)]));
+    }
+  }),
 
-      const response = await BackendRepository.login(payload);
-
+  graphql.query("GetProfile", async (req, res, ctx) => {
+    try {
+      const { id } = req.variables;
+      const response = await BackendRepository.profile(+id);
       return res(ctx.data(response));
     } catch (err) {
       return res(ctx.errors([RepositoryError.toJson(err)]));

--- a/src/backend/handlers/user.ts
+++ b/src/backend/handlers/user.ts
@@ -3,12 +3,9 @@ import { BackendRepository, RepositoryError } from "../db";
 import { makeUrl } from "../utils";
 
 export const restHandlers = [
-  rest.post(makeUrl("login"), async (req, res, ctx) => {
+  rest.get(makeUrl("users"), async (req, res, ctx) => {
     try {
-      const payload = await req.json();
-
-      const response = await BackendRepository.login(payload);
-
+      const response = await BackendRepository.userList();
       return res(ctx.status(200), ctx.json(response));
     } catch (err) {
       const error = RepositoryError.toJson(err);
@@ -16,13 +13,10 @@ export const restHandlers = [
     }
   }),
 
-  rest.post(makeUrl("refresh"), async (req, res, ctx) => {
+  rest.get(makeUrl("users/:id"), async (req, res, ctx) => {
     try {
-      const payload = await req.json();
-      const encodedToken = req.headers.get("Authorization");
-
-      const response = await BackendRepository.refresh(payload, encodedToken);
-
+      const { id } = req.params;
+      const response = await BackendRepository.user(+id);
       return res(ctx.status(200), ctx.json(response));
     } catch (err) {
       const error = RepositoryError.toJson(err);
@@ -32,12 +26,19 @@ export const restHandlers = [
 ];
 
 export const gqlHandlers = [
-  graphql.mutation("Login", async (req, res, ctx) => {
+  graphql.query("GetUsers", async (req, res, ctx) => {
     try {
-      const payload = req.variables;
+      const response = await BackendRepository.userList();
+      return res(ctx.data(response));
+    } catch (err) {
+      return res(ctx.errors([RepositoryError.toJson(err)]));
+    }
+  }),
 
-      const response = await BackendRepository.login(payload);
-
+  graphql.query("GetUser", async (req, res, ctx) => {
+    try {
+      const { id } = req.variables;
+      const response = await BackendRepository.user(+id);
       return res(ctx.data(response));
     } catch (err) {
       return res(ctx.errors([RepositoryError.toJson(err)]));

--- a/src/backend/utils/makeUrl.ts
+++ b/src/backend/utils/makeUrl.ts
@@ -1,5 +1,5 @@
-export function makeUrl(path = "") {
+export function makeUrl(path = "", prefix = "/api") {
   const baseURl = window.location.origin;
-  const url = new URL(`api/${path}`, baseURl);
+  const url = new URL(`${prefix}/${path}`, baseURl);
   return url.toString();
 }

--- a/src/features/Root.tsx
+++ b/src/features/Root.tsx
@@ -35,6 +35,7 @@ export function Root() {
           <Link to="/query">query</Link>
           <Link to="/swr">swr</Link>
           <Link to="/toolkit-query"> toolkit query </Link>
+          <Link to="/gql"> Gql </Link>
           {!!session && !!session.token && !!session.refreshToken && (
             <Link
               to=""

--- a/src/features/gql/Gql.tsx
+++ b/src/features/gql/Gql.tsx
@@ -1,0 +1,5 @@
+import { Outlet } from "react-router-dom";
+
+export function GqlRoot() {
+  return <Outlet />;
+}

--- a/src/features/gql/GqlLogin.tsx
+++ b/src/features/gql/GqlLogin.tsx
@@ -1,0 +1,44 @@
+import { useNavigate } from "react-router-dom";
+import { Login } from "@components";
+import { loginResSchema, TLoginReq, TLoginRes } from "@models";
+import { httpClient, TokenRegistry } from "@utils";
+
+async function login(variables: TLoginReq): Promise<TLoginRes> {
+  const { data } = (await httpClient("gql/", {
+    method: "POST",
+    body: JSON.stringify({
+      query: `
+      mutation Login($username: String!, $password: String!){
+        Login(username: $username, password: $password){
+          token
+          refreshToken
+        }
+      }`,
+      variables,
+    }),
+  })) as any;
+  return loginResSchema.parse(data);
+}
+
+export function GqlLogin() {
+  const navigate = useNavigate();
+
+  return (
+    <Login
+      title="Query login"
+      onLogin={async (value) => {
+        try {
+          const data = await login(value);
+          TokenRegistry.token = data.token;
+          TokenRegistry.refreshToken = data.refreshToken;
+          TokenRegistry.user = data.user;
+          navigate("users");
+        } catch (e) {
+          console.log("err", e);
+        }
+      }}
+      loading={false}
+      error={undefined}
+    />
+  );
+}

--- a/src/features/gql/GqlUserProfile.tsx
+++ b/src/features/gql/GqlUserProfile.tsx
@@ -1,0 +1,51 @@
+import { useEffect, useState } from "react";
+import { useParams } from "react-router-dom";
+import { UserProfile } from "@components";
+import { TUser } from "@models";
+import { httpClient } from "@utils";
+
+async function getUser(id: number, signal: AbortSignal) {
+  const { data } = (await httpClient("gql/", {
+    method: "POST",
+    body: JSON.stringify({
+      query: `
+      query GetUser($id: Int!) {
+        GetUser(id: $id){
+          user
+        }
+      }`,
+      variables: { id },
+    }),
+    signal,
+  })) as any;
+  return data;
+}
+
+export function GqlUserProfile() {
+  const { id } = useParams<{ id: string }>();
+  const [user, setUser] = useState<TUser | undefined>(undefined);
+
+  useEffect(() => {
+    if (!id) return;
+
+    const ab = new AbortController();
+
+    getUser(+id, ab.signal)
+      .then((user) => setUser(user))
+      .catch(console.error);
+
+    return () => {
+      ab.abort();
+    };
+  }, [id]);
+
+  return (
+    <UserProfile
+      user={user}
+      loading={false}
+      error={undefined}
+      // eslint-disable-next-line @typescript-eslint/no-empty-function
+      retry={() => {}}
+    />
+  );
+}

--- a/src/features/gql/GqlUsers.tsx
+++ b/src/features/gql/GqlUsers.tsx
@@ -1,0 +1,51 @@
+import { useEffect, useState } from "react";
+import { Table } from "@mantine/core";
+import { httpClient } from "@utils";
+
+export function GqlUsers() {
+  const [users, setUsers] = useState<{ id: number; username: string }[]>([]);
+
+  useEffect(() => {
+    const ab = new AbortController();
+
+    httpClient("gql/", {
+      method: "POST",
+      body: JSON.stringify({
+        query: `query GetUsers {
+            users {
+                id
+                username
+            }
+        }`,
+        variables: {},
+      }),
+    })
+      .then((json) => {
+        setUsers((json as any).data.users);
+      })
+      .catch(console.error);
+
+    return () => {
+      ab.abort();
+    };
+  }, []);
+
+  return (
+    <Table>
+      <thead>
+        <tr>
+          <th>ID</th>
+          <th>Username</th>
+        </tr>
+      </thead>
+      <tbody>
+        {users?.map((user) => (
+          <tr key={user.id}>
+            <td>{user.id}</td>
+            <td>{user.username}</td>
+          </tr>
+        ))}
+      </tbody>
+    </Table>
+  );
+}

--- a/src/features/gql/index.tsx
+++ b/src/features/gql/index.tsx
@@ -1,0 +1,14 @@
+import { RouteObject } from "react-router";
+import { GqlRoot } from "./Gql";
+import { GqlUsers } from "./GqlUsers";
+
+export const gqlRoutes: RouteObject = {
+  path: "gql",
+  element: <GqlRoot />,
+  children: [
+    {
+      index: true,
+      element: <GqlUsers />,
+    },
+  ],
+};

--- a/src/features/gql/index.tsx
+++ b/src/features/gql/index.tsx
@@ -1,5 +1,7 @@
 import { RouteObject } from "react-router";
 import { GqlRoot } from "./Gql";
+import { GqlLogin } from "./GqlLogin";
+import { GqlUserProfile } from "./GqlUserProfile";
 import { GqlUsers } from "./GqlUsers";
 
 export const gqlRoutes: RouteObject = {
@@ -8,7 +10,17 @@ export const gqlRoutes: RouteObject = {
   children: [
     {
       index: true,
+      element: <GqlLogin />,
+    },
+    {
+      path: "users",
       element: <GqlUsers />,
+      children: [
+        {
+          path: ":id",
+          element: <GqlUserProfile />,
+        },
+      ],
     },
   ],
 };

--- a/src/features/index.ts
+++ b/src/features/index.ts
@@ -1,3 +1,4 @@
+export * from "./gql";
 export * from "./query";
 export * from "./Root";
 export * from "./swr";

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -1,12 +1,18 @@
 import { RouteObject } from "react-router";
 import { ErrorPage } from "@components";
-import { queryRoutes, Root, swrRoutes, toolkitRoutes } from "@features";
+import {
+  gqlRoutes,
+  queryRoutes,
+  Root,
+  swrRoutes,
+  toolkitRoutes,
+} from "@features";
 
 export const routes: RouteObject[] = [
   {
     path: "/",
     element: <Root />,
     errorElement: <ErrorPage />,
-    children: [queryRoutes, swrRoutes, toolkitRoutes],
+    children: [queryRoutes, swrRoutes, toolkitRoutes, gqlRoutes],
   },
 ];

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -12,7 +12,7 @@ export default defineConfig({
     tsconfigPaths(),
     { ...eslint({ failOnWarning: true }), apply: "build" },
     {
-      ...eslint({ fix: true, failOnError: false, failOnWarning: false }),
+      ...eslint({ fix: false, failOnError: false, failOnWarning: false }),
       apply: "serve",
       enforce: "post",
     },


### PR DESCRIPTION
### This PR lays the blocks for `graphql` support.

 Currently `mswjs/data` doesn't support relations with [graphql](https://github.com/mswjs/data/issues/99). This PR aims to normalise the backend data so it can display the same data as rest endpoint.

Will enable the exploration of new query libraries:

- [urql](https://formidable.com/open-source/urql/)
- [apollo](https://www.apollographql.com/)

Also currently implemented query libs with graphql.

Todo:
- [x] explore [graphql codegen](https://the-guild.dev/graphql/codegen)

